### PR TITLE
chore: rename symbols to avoid name conflicts

### DIFF
--- a/oci8.go.h
+++ b/oci8.go.h
@@ -1,2 +1,6 @@
+#define hash_search ob_hash_search
+#define list_free ob_list_free
 #include <oci.h>
+#undef hash_search
+#undef list_free
 #include <stdlib.h>


### PR DESCRIPTION
# Steps:
1. 
run `objcopy --redefine-syms=redefine_syms ./x86_64/lib/libobci.a` where `redefine-syms` is the following

```
hash_search ob_hash_search
list_free ob_list_free
```

2. modify headers